### PR TITLE
Teach testCoverage() to work with testthat by default

### DIFF
--- a/R/testCoverage.R
+++ b/R/testCoverage.R
@@ -26,6 +26,15 @@
 #' \code{\link{cranCoverage}}
 #' @author Mango Solutions\email{support@@mango-solutions.com}
 #' @export
-testCoverage <- function(source.files, test.files, ...) {
-  reportCoverage(sourcefiles = source.files, executionfiles = test.files, ...)
+testCoverage <- function(source.files=dir("R", full=TRUE), test.files=dir("tests/testthat/", full=TRUE), ...) {
+  if(any(grepl("testthat", test.files))) {
+    if(!require(testthat)) stop("Package 'testthat' must be installed and loaded.")
+    orig_dir <- getwd()
+    source.files <- file.path(orig_dir, source.files)
+    test.files <- file.path(orig_dir, test.files)
+    setwd(file.path("tests", "testthat"))
+  }
+  res <- reportCoverage(sourcefiles = source.files, executionfiles = test.files, ...)
+  setwd(orig_dir)
+  res
 }

--- a/man/testCoverage.Rd
+++ b/man/testCoverage.Rd
@@ -2,7 +2,8 @@
 \alias{testCoverage}
 \title{Code coverage test files.}
 \usage{
-testCoverage(source.files, test.files, ...)
+testCoverage(source.files = dir("R", full = TRUE),
+  test.files = dir("tests/testthat/", full = TRUE), ...)
 }
 \arguments{
   \item{source.files}{character vector of source code


### PR DESCRIPTION
This makes it a little more convenient to test a package developed using [devtools](https://github.com/hadley/devtools/) and [testthat](https://github.com/hadley/testthat/).
